### PR TITLE
Import single lodash function instead of all of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var assign = require('lodash/object/assign')
 var React = require('react')
 
 module.exports = React.createClass({
@@ -59,6 +59,6 @@ module.exports = React.createClass({
       className += ' ' + this.props.className
     }
 
-    return React.createElement('span', _.assign({}, this.props, { className: className }))
+    return React.createElement('span', assign({}, this.props, { className: className }))
   }
 })


### PR DESCRIPTION
Doing this will cut down the published package size, since we don't need to import all of lodash when we're only going to use a single function.