### PR TITLE
Upgrade to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [ "es2015", "react" ],
+  "plugins": [ "add-module-exports" ]
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "babel": "^5.8.23",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.4",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "chai": "^3.2.0",
     "eslint": "^1.2.1",
     "eslint-plugin-nodeca": "^1.0.3",
@@ -65,7 +69,6 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "dependencies": {},
   "peerDependencies": {
     "react": ">=0.12.0"
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./test/helper.js
---compilers js:babel/register
+--compilers js:babel-core/register
 --reporter list
 --ui bdd


### PR DESCRIPTION
- Upgraded Babel to v6 which entails using babel-cli and babel-core instead of babel
- Configured babelrc to use ES2015 and React presets
- Made Mocha use babel-register