### PR TITLE
Filter which props are passed into the underlying span

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [ "es2015", "react" ],
+  "presets": [ "es2015", "stage-2", "react" ],
   "plugins": [ "add-module-exports" ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   },
   "parserOptions": {
     "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
       "globalReturn": true,
       "jsx": true
     },

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - 'node'
 script: 'npm test'

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "chai": "^3.2.0",
     "eslint": "^2.5.3",
     "eslint-plugin-nodeca": "^1.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -37,42 +37,56 @@ export default React.createClass({
   },
 
   render() {
-    let className = 'fa fa-' + this.props.name
+    let {
+      border,
+      fixedWidth,
+      flip,
+      inverse,
+      name,
+      pulse,
+      rotate,
+      size,
+      spin,
+      stack,
+      ...props,
+    } = this.props
 
-    if (this.props.size) {
-      className += ' fa-' + this.props.size
+    let className = 'fa fa-' + name
+
+    if (size) {
+      className += ' fa-' + size
     }
 
-    if (this.props.spin) {
+    if (spin) {
       className += ' fa-spin'
     }
 
-    if (this.props.pulse) {
+    if (pulse) {
       className += ' fa-pulse'
     }
 
-    if (this.props.border) {
+    if (border) {
       className += ' fa-border'
     }
 
-    if (this.props.fixedWidth) {
+    if (fixedWidth) {
       className += ' fa-fw'
     }
 
-    if (this.props.inverse) {
+    if (inverse) {
       className += ' fa-inverse'
     }
 
-    if (this.props.flip) {
-      className += ' fa-flip-' + this.props.flip
+    if (flip) {
+      className += ' fa-flip-' + flip
     }
 
-    if (this.props.rotate) {
-      className += ' fa-rotate-' + this.props.rotate
+    if (rotate) {
+      className += ' fa-rotate-' + rotate
     }
 
-    if (this.props.stack) {
-      className += ' fa-stack-' + this.props.stack
+    if (stack) {
+      className += ' fa-stack-' + stack
     }
 
     if (this.props.className) {
@@ -81,7 +95,7 @@ export default React.createClass({
 
     return (
       <span
-        {...this.props}
+        {...props}
         className={className}
       />
     )

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,6 +6,7 @@ import jsdom from 'mocha-jsdom'
 import FontAwesome from '../src'
 
 describe('FontAwesome', () => {
+  let component
   let classes
 
   // Use mocha-jsdom.
@@ -25,7 +26,7 @@ describe('FontAwesome', () => {
       rotate: 180,
       stack: '1x',
     }
-    const component = ReactDOM.render(<FontAwesome {...props} />, document.body)
+    component = ReactDOM.render(<FontAwesome {...props} />, document.body)
     classes = ReactDOM.findDOMNode(component).className.split(' ')
   })
 
@@ -47,5 +48,9 @@ describe('FontAwesome', () => {
     expectedClasses.forEach(className => {
       expect(classes.indexOf(className)).to.be.above(-1)
     })
+  })
+
+  it('the "name" prop is not rendered in the markup', () => {
+    expect(ReactDOM.findDOMNode(component).name).to.be.undefined
   })
 })


### PR DESCRIPTION
Previously the JSX splat syntax was used to pass `this.props` in its entirety into the underlying `<span>` component. This resulted in invalid HTML markup because the `name` prop was rendered in the markup, and according to the W3 HTML checker it's invalid to have a `name` prop on a `<span>` in most contexts.
    
So instead, we split out the FontAwesome-specific props from the rest of them, and pass only the non-FontAwesome props down to the `<span>`.
    
Test Plan: Added a regression test