### PR TITLE
[Tests] Use the modern ReactDOM.render+findDOMNode APIs for React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "mocha-sinon": "^1.1.4",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
     "sinon": "^1.16.1",
     "sinon-chai": "^2.8.0"
   },

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,6 +1,7 @@
 /* eslint no-unused-expressions:0 */
 
 import React from 'react'
+import ReactDOM from 'react-dom'
 import jsdom from 'mocha-jsdom'
 import FontAwesome from '../src'
 
@@ -24,8 +25,8 @@ describe('FontAwesome', () => {
       rotate: 180,
       stack: '1x',
     }
-    const component = React.render(<FontAwesome {...props} />, document.body)
-    classes = component.getDOMNode().className.split(' ')
+    const component = ReactDOM.render(<FontAwesome {...props} />, document.body)
+    classes = ReactDOM.findDOMNode(component).className.split(' ')
   })
 
   it('the proper class names get set', () => {


### PR DESCRIPTION
React 0.14 introduced these two new methods, and React 15 made them the only want to render elements and find DOM nodes so the test suite was failing. This commit adds react and react-dom to package.json's devDependencies (since the tests require them) and updates the tests to use the new API.

Fixes #9 

Test Plan: `npm test` passes.
