### PR TITLE
Add option to pass FontAwesome as css module

### DIFF
--- a/api.md
+++ b/api.md
@@ -8,6 +8,7 @@ A React component for the font-awesome icon library.
 | --- | --- | --- | --- |
 | [border] | <code>Boolean</code> | <code>false</code> | Whether or not to show a border radius |
 | [className] | <code>String</code> |  | An extra set of CSS classes to add to the component |
+| [cssModule] | <code>Object</code> |  | Option to pass FontAwesome CSS as a module |
 | [fixedWidth] | <code>Boolean</code> | <code>false</code> | Make buttons fixed width |
 | [flip] | <code>String</code> | <code>false</code> | Flip the icon's orientation. |
 | [inverse] | <code>Boolean</code> | <code>false</code> | the icon's color |

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import React from 'react'
  *
  * @param {Boolean} [border=false] Whether or not to show a border radius
  * @param {String} [className] An extra set of CSS classes to add to the component
+ * @param {Object} [cssModule] Option to pass FontAwesome CSS as a module
  * @param {Boolean} [fixedWidth=false] Make buttons fixed width
  * @param {String} [flip=false] Flip the icon's orientation.
  * @param {Boolean} [inverse=false]Inverse the icon's color
@@ -25,6 +26,7 @@ export default React.createClass({
   propTypes: {
     border: React.PropTypes.bool,
     className: React.PropTypes.string,
+    cssModule: React.PropTypes.object,
     fixedWidth: React.PropTypes.bool,
     flip: React.PropTypes.oneOf([ 'horizontal', 'vertical' ]),
     inverse: React.PropTypes.bool,
@@ -39,6 +41,7 @@ export default React.createClass({
   render() {
     let {
       border,
+      cssModule,
       fixedWidth,
       flip,
       inverse,
@@ -51,48 +54,92 @@ export default React.createClass({
       ...props,
     } = this.props
 
-    let className = 'fa fa-' + name
+    let className = ''
+    if (cssModule) {
+      className = `${cssModule.fa} ${cssModule['fa-' + name]}`
 
-    if (size) {
-      className += ' fa-' + size
+      if (size) {
+        className += ` ${cssModule['fa-' + size]}`
+      }
+
+      if (spin) {
+        className += ` ${cssModule['fa-spin']}`
+      }
+
+      if (pulse) {
+        className += ` ${cssModule['fa-pulse']}`
+      }
+
+      if (border) {
+        className += ` ${cssModule['fa-border']}`
+      }
+
+      if (fixedWidth) {
+        className += ` ${cssModule['fa-fw']}`
+      }
+
+      if (inverse) {
+        className += ` ${cssModule['fa-inverse']}`
+      }
+
+      if (flip) {
+        className += ` ${cssModule['fa-flip-' + flip]}`
+      }
+
+      if (rotate) {
+        className += ` ${cssModule['fa-rotate-' + rotate]}`
+      }
+
+      if (stack) {
+        className += ` ${cssModule['fa-stack-' + stack]}`
+      }
+
+      if (this.props.className) {
+        className += ` ${cssModule[this.props.className]}`
+      }
+    } else {
+      className = 'fa fa-' + name
+
+      if (size) {
+        className += ' fa-' + size
+      }
+
+      if (spin) {
+        className += ' fa-spin'
+      }
+
+      if (pulse) {
+        className += ' fa-pulse'
+      }
+
+      if (border) {
+        className += ' fa-border'
+      }
+
+      if (fixedWidth) {
+        className += ' fa-fw'
+      }
+
+      if (inverse) {
+        className += ' fa-inverse'
+      }
+
+      if (flip) {
+        className += ' fa-flip-' + flip
+      }
+
+      if (rotate) {
+        className += ' fa-rotate-' + rotate
+      }
+
+      if (stack) {
+        className += ' fa-stack-' + stack
+      }
+
+      if (this.props.className) {
+        className += ' ' + this.props.className
+      }
     }
-
-    if (spin) {
-      className += ' fa-spin'
-    }
-
-    if (pulse) {
-      className += ' fa-pulse'
-    }
-
-    if (border) {
-      className += ' fa-border'
-    }
-
-    if (fixedWidth) {
-      className += ' fa-fw'
-    }
-
-    if (inverse) {
-      className += ' fa-inverse'
-    }
-
-    if (flip) {
-      className += ' fa-flip-' + flip
-    }
-
-    if (rotate) {
-      className += ' fa-rotate-' + rotate
-    }
-
-    if (stack) {
-      className += ' fa-stack-' + stack
-    }
-
-    if (this.props.className) {
-      className += ' ' + this.props.className
-    }
-
     return (
       <span
         {...props}

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export default React.createClass({
       }
 
       if (this.props.className) {
-        className += ` ${cssModule[this.props.className]}`
+        className += ' ' + this.props.className
       }
     } else {
       className = 'fa fa-' + name

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -27,7 +27,6 @@ describe('FontAwesome', () => {
       'fa-rotate-180': 'fa-rotate-180_1',
       'fa-spin': 'fa-spin_1',
       'fa-stack-1x': 'fa-stack-1x_1',
-      'my-custom-class': 'my-custom-class_1',
     }
 
     const props = {
@@ -88,7 +87,7 @@ describe('FontAwesome', () => {
       'fa-rotate-180_1',
       'fa-spin_1',
       'fa-stack-1x_1',
-      'my-custom-class_1',
+      'my-custom-class',
     ]
     expectedClasses.forEach(className => {
       expect(cssModuleClasses.indexOf(className)).to.be.above(-1)

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -8,11 +8,28 @@ import FontAwesome from '../src'
 describe('FontAwesome', () => {
   let component
   let classes
+  let cssModuleComponent
+  let cssModuleClasses
 
   // Use mocha-jsdom.
   jsdom({ html: '<div id="root"></div>' })
 
   beforeEach(() => {
+    const cssModule = {
+      fa: 'fa_1',
+      'fa-border': 'fa-border_1',
+      'fa-flip-vertical': 'fa-flip-vertical_1',
+      'fa-fw': 'fa-fw_1',
+      'fa-inverse': 'fa-inverse_1',
+      'fa-lg': 'fa-lg_1',
+      'fa-rocket': 'fa-rocket_1',
+      'fa-pulse': 'fa-pulse_1',
+      'fa-rotate-180': 'fa-rotate-180_1',
+      'fa-spin': 'fa-spin_1',
+      'fa-stack-1x': 'fa-stack-1x_1',
+      'my-custom-class': 'my-custom-class_1',
+    }
+
     const props = {
       border: true,
       className: 'my-custom-class',
@@ -28,6 +45,10 @@ describe('FontAwesome', () => {
     }
     component = ReactDOM.render(<FontAwesome {...props} />, document.getElementById('root'))
     classes = ReactDOM.findDOMNode(component).className.split(' ')
+
+    cssModuleComponent = ReactDOM.render(<FontAwesome {...props} cssModule={cssModule} />,
+      document.getElementById('root'))
+    cssModuleClasses = ReactDOM.findDOMNode(cssModuleComponent).className.split(' ')
   })
 
   it('the proper class names get set', () => {
@@ -53,4 +74,29 @@ describe('FontAwesome', () => {
   it('the "name" prop is not rendered in the markup', () => {
     expect(ReactDOM.findDOMNode(component).name).to.be.undefined
   })
+
+  it('correct class names get set using cssModule style', () => {
+    const expectedClasses = [
+      'fa_1',
+      'fa-border_1',
+      'fa-flip-vertical_1',
+      'fa-fw_1',
+      'fa-inverse_1',
+      'fa-lg_1',
+      'fa-rocket_1',
+      'fa-pulse_1',
+      'fa-rotate-180_1',
+      'fa-spin_1',
+      'fa-stack-1x_1',
+      'my-custom-class_1',
+    ]
+    expectedClasses.forEach(className => {
+      expect(cssModuleClasses.indexOf(className)).to.be.above(-1)
+    })
+  })
+
+  it('the "name" prop is not rendered in the markup using cssModule style', () => {
+    expect(ReactDOM.findDOMNode(cssModuleComponent).name).to.be.undefined
+  })
+
 })


### PR DESCRIPTION
react-fontawesome requires FontAwesome CSS to be included elsewhere in the project. I am working on a project that uses CSS modules and have included FontAwesome as a module. This commit adds a prop called cssModule, which is used to look up the FontAwesome css within the object, if passed. Otherwise API and usage are identical.

Also included are two extra tests that replicate the current tests, but supplying CSS class names using the cssModule prop.