### PR TITLE
use prop-types package instead of deprecated React.PropTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _screenReaderStyles = require('./screen-reader-styles');
 
 var _screenReaderStyles2 = _interopRequireDefault(_screenReaderStyles);
@@ -44,41 +48,40 @@ exports.default = _react2.default.createClass({
   displayName: 'FontAwesome',
 
   propTypes: {
-    ariaLabel: _react2.default.PropTypes.string,
-    border: _react2.default.PropTypes.bool,
-    className: _react2.default.PropTypes.string,
-    cssModule: _react2.default.PropTypes.object,
-    fixedWidth: _react2.default.PropTypes.bool,
-    flip: _react2.default.PropTypes.oneOf(['horizontal', 'vertical']),
-    inverse: _react2.default.PropTypes.bool,
-    name: _react2.default.PropTypes.string.isRequired,
-    pulse: _react2.default.PropTypes.bool,
-    rotate: _react2.default.PropTypes.oneOf([90, 180, 270]),
-    size: _react2.default.PropTypes.oneOf(['lg', '2x', '3x', '4x', '5x']),
-    spin: _react2.default.PropTypes.bool,
-    stack: _react2.default.PropTypes.oneOf(['1x', '2x']),
-    tag: _react2.default.PropTypes.string
+    ariaLabel: _propTypes2.default.string,
+    border: _propTypes2.default.bool,
+    className: _propTypes2.default.string,
+    cssModule: _propTypes2.default.object,
+    fixedWidth: _propTypes2.default.bool,
+    flip: _propTypes2.default.oneOf(['horizontal', 'vertical']),
+    inverse: _propTypes2.default.bool,
+    name: _propTypes2.default.string.isRequired,
+    pulse: _propTypes2.default.bool,
+    rotate: _propTypes2.default.oneOf([90, 180, 270]),
+    size: _propTypes2.default.oneOf(['lg', '2x', '3x', '4x', '5x']),
+    spin: _propTypes2.default.bool,
+    stack: _propTypes2.default.oneOf(['1x', '2x']),
+    tag: _propTypes2.default.string
   },
 
   render: function render() {
-    var _props = this.props;
-    var border = _props.border;
-    var cssModule = _props.cssModule;
-    var className = _props.className;
-    var fixedWidth = _props.fixedWidth;
-    var flip = _props.flip;
-    var inverse = _props.inverse;
-    var name = _props.name;
-    var pulse = _props.pulse;
-    var rotate = _props.rotate;
-    var size = _props.size;
-    var spin = _props.spin;
-    var stack = _props.stack;
-    var _props$tag = _props.tag;
-    var tag = _props$tag === undefined ? 'span' : _props$tag;
-    var ariaLabel = _props.ariaLabel;
-
-    var props = _objectWithoutProperties(_props, ['border', 'cssModule', 'className', 'fixedWidth', 'flip', 'inverse', 'name', 'pulse', 'rotate', 'size', 'spin', 'stack', 'tag', 'ariaLabel']);
+    var _props = this.props,
+        border = _props.border,
+        cssModule = _props.cssModule,
+        className = _props.className,
+        fixedWidth = _props.fixedWidth,
+        flip = _props.flip,
+        inverse = _props.inverse,
+        name = _props.name,
+        pulse = _props.pulse,
+        rotate = _props.rotate,
+        size = _props.size,
+        spin = _props.spin,
+        stack = _props.stack,
+        _props$tag = _props.tag,
+        tag = _props$tag === undefined ? 'span' : _props$tag,
+        ariaLabel = _props.ariaLabel,
+        props = _objectWithoutProperties(_props, ['border', 'cssModule', 'className', 'fixedWidth', 'flip', 'inverse', 'name', 'pulse', 'rotate', 'size', 'spin', 'stack', 'tag', 'ariaLabel']);
 
     var classNames = [];
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "mocha-sinon": "^1.1.4",
-    "prop-types": "^15.5.4",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "sinon": "^1.16.1",
@@ -73,7 +72,9 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "prop-types": ">=15.5.4",
     "react": ">=0.12.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "mocha-sinon": "^1.1.4",
+    "prop-types": "^15.5.4",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "sinon": "^1.16.1",
@@ -72,6 +73,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
+    "prop-types": ">=15.5.4",
     "react": ">=0.12.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import srOnlyStyle from './screen-reader-styles'
 
 /**
@@ -27,20 +28,20 @@ export default React.createClass({
   displayName: 'FontAwesome',
 
   propTypes: {
-    ariaLabel: React.PropTypes.string,
-    border: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    cssModule: React.PropTypes.object,
-    fixedWidth: React.PropTypes.bool,
-    flip: React.PropTypes.oneOf([ 'horizontal', 'vertical' ]),
-    inverse: React.PropTypes.bool,
-    name: React.PropTypes.string.isRequired,
-    pulse: React.PropTypes.bool,
-    rotate: React.PropTypes.oneOf([ 90, 180, 270 ]),
-    size: React.PropTypes.oneOf([ 'lg', '2x', '3x', '4x', '5x' ]),
-    spin: React.PropTypes.bool,
-    stack: React.PropTypes.oneOf([ '1x', '2x' ]),
-    tag: React.PropTypes.string,
+    ariaLabel: PropTypes.string,
+    border: PropTypes.bool,
+    className: PropTypes.string,
+    cssModule: PropTypes.object,
+    fixedWidth: PropTypes.bool,
+    flip: PropTypes.oneOf([ 'horizontal', 'vertical' ]),
+    inverse: PropTypes.bool,
+    name: PropTypes.string.isRequired,
+    pulse: PropTypes.bool,
+    rotate: PropTypes.oneOf([ 90, 180, 270 ]),
+    size: PropTypes.oneOf([ 'lg', '2x', '3x', '4x', '5x' ]),
+    spin: PropTypes.bool,
+    stack: PropTypes.oneOf([ '1x', '2x' ]),
+    tag: PropTypes.string,
   },
 
   render() {


### PR DESCRIPTION
this adds another dependency but avoids deprecation warnings/errors once React.PropTypes are removed
(see https://facebook.github.io/react/docs/typechecking-with-proptypes.html)