### PR TITLE
Add support for FontAwesome ul > li bullets

### DIFF
--- a/lib/FALI.js
+++ b/lib/FALI.js
@@ -1,0 +1,28 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _utils = require('./utils/');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var fali = function fali(props) {
+  var classNames = (0, _utils.formatClassName)(props, 'fa-li fa');
+  var passthroughProps = (0, _utils.getPassthroughProps)(props);
+
+  return _react2.default.createElement(
+    'li',
+    passthroughProps,
+    _react2.default.createElement('i', { className: classNames.join(' ') }),
+    props.children
+  );
+};
+
+exports.default = fali;
+module.exports = exports['default'];

--- a/lib/FAUL.js
+++ b/lib/FAUL.js
@@ -1,0 +1,29 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _utils = require('./utils/');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var faul = function faul(props) {
+  var classNames = (0, _utils.formatClassName)(props, 'fa-ul');
+  var passthroughProps = (0, _utils.getPassthroughProps)(props);
+
+  return _react2.default.createElement(
+    'ul',
+    _extends({ className: classNames.join(' ') }, passthroughProps),
+    props.children
+  );
+};
+
+exports.default = faul;
+module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.FALI = exports.FAUL = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -19,6 +20,16 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 var _screenReaderStyles = require('./screen-reader-styles');
 
 var _screenReaderStyles2 = _interopRequireDefault(_screenReaderStyles);
+
+var _utils = require('./utils/');
+
+var _FAUL = require('./FAUL');
+
+var _FAUL2 = _interopRequireDefault(_FAUL);
+
+var _FALI = require('./FALI');
+
+var _FALI2 = _interopRequireDefault(_FALI);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -65,55 +76,15 @@ var FontAwesome = function (_React$Component) {
   _createClass(FontAwesome, [{
     key: 'render',
     value: function render() {
-      var _props = this.props,
-          border = _props.border,
-          cssModule = _props.cssModule,
-          className = _props.className,
-          fixedWidth = _props.fixedWidth,
-          flip = _props.flip,
-          inverse = _props.inverse,
-          name = _props.name,
-          pulse = _props.pulse,
-          rotate = _props.rotate,
-          size = _props.size,
-          spin = _props.spin,
-          stack = _props.stack,
-          _props$tag = _props.tag,
-          tag = _props$tag === undefined ? 'span' : _props$tag,
-          ariaLabel = _props.ariaLabel,
-          props = _objectWithoutProperties(_props, ['border', 'cssModule', 'className', 'fixedWidth', 'flip', 'inverse', 'name', 'pulse', 'rotate', 'size', 'spin', 'stack', 'tag', 'ariaLabel']);
+      var classNames = (0, _utils.formatClassName)(this.props, 'fa');
 
-      var classNames = [];
+      var _getPassthroughProps = (0, _utils.getPassthroughProps)(this.props),
+          _getPassthroughProps$ = _getPassthroughProps.tag,
+          tag = _getPassthroughProps$ === undefined ? 'span' : _getPassthroughProps$,
+          ariaLabel = _getPassthroughProps.ariaLabel,
+          leftoverProps = _objectWithoutProperties(_getPassthroughProps, ['tag', 'ariaLabel']);
 
-      if (cssModule) {
-        classNames.push(cssModule['fa']);
-        classNames.push(cssModule['fa-' + name]);
-        size && classNames.push(cssModule['fa-' + size]);
-        spin && classNames.push(cssModule['fa-spin']);
-        pulse && classNames.push(cssModule['fa-pulse']);
-        border && classNames.push(cssModule['fa-border']);
-        fixedWidth && classNames.push(cssModule['fa-fw']);
-        inverse && classNames.push(cssModule['fa-inverse']);
-        flip && classNames.push(cssModule['fa-flip-' + flip]);
-        rotate && classNames.push(cssModule['fa-rotate-' + rotate]);
-        stack && classNames.push(cssModule['fa-stack-' + stack]);
-      } else {
-        classNames.push('fa');
-        classNames.push('fa-' + name);
-        size && classNames.push('fa-' + size);
-        spin && classNames.push('fa-spin');
-        pulse && classNames.push('fa-pulse');
-        border && classNames.push('fa-border');
-        fixedWidth && classNames.push('fa-fw');
-        inverse && classNames.push('fa-inverse');
-        flip && classNames.push('fa-flip-' + flip);
-        rotate && classNames.push('fa-rotate-' + rotate);
-        stack && classNames.push('fa-stack-' + stack);
-      }
-
-      // Add any custom class names at the end.
-      className && classNames.push(className);
-      return _react2.default.createElement(tag, _extends({}, props, { 'aria-hidden': true, className: classNames.join(' ') }), ariaLabel ? _react2.default.createElement('span', { style: _screenReaderStyles2.default }, ariaLabel) : null);
+      return _react2.default.createElement(tag, _extends({}, leftoverProps, { 'aria-hidden': true, className: classNames.join(' ') }), ariaLabel ? _react2.default.createElement('span', { style: _screenReaderStyles2.default }, ariaLabel) : null);
     }
   }]);
 
@@ -138,4 +109,5 @@ FontAwesome.propTypes = {
 };
 
 exports.default = FontAwesome;
-module.exports = exports['default'];
+exports.FAUL = _FAUL2.default;
+exports.FALI = _FALI2.default;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,0 +1,86 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+var formatClassName = exports.formatClassName = function formatClassName(props, base) {
+  var className = props.className,
+      cssModule = props.cssModule;
+
+  var propsToFormat = ['name', 'size', 'spin', 'pulse', 'border', 'fixedWidth', 'inverse', 'flip', 'rotate', 'stack'];
+
+  var output = cssModule ? [cssModule[base]] : [base];
+
+  var simpleFormatter = function simpleFormatter(appendValue) {
+    return 'fa-' + appendValue;
+  };
+
+  var complexFormatter = function complexFormatter(appendValue1, appendValue2) {
+    return 'fa-' + appendValue1 + '-' + appendValue2;
+  };
+
+  var formatterMap = {
+    name: function name(_name) {
+      return simpleFormatter(_name);
+    },
+    size: function size(_size) {
+      return simpleFormatter(_size);
+    },
+    spin: function spin() {
+      return simpleFormatter('spin');
+    },
+    pulse: function pulse() {
+      return simpleFormatter('pulse');
+    },
+    border: function border() {
+      return simpleFormatter('border');
+    },
+    fixedWidth: function fixedWidth() {
+      return simpleFormatter('fw');
+    },
+    inverse: function inverse() {
+      return simpleFormatter('inverse');
+    },
+    flip: function flip(flipVal) {
+      return complexFormatter('flip', flipVal);
+    },
+    rotate: function rotate(rotateVal) {
+      return complexFormatter('rotate', rotateVal);
+    },
+    stack: function stack(stackVal) {
+      return complexFormatter('stack', stackVal);
+    }
+  };
+
+  propsToFormat.map(function (x) {
+    return { name: x, val: props[x] };
+  }).reduce(function (accumulator, currentValue) {
+    return currentValue.val ? output.push(cssModule ? cssModule[formatterMap[currentValue.name](currentValue.val)] : formatterMap[currentValue.name](currentValue.val)) : output;
+  }, output);
+
+  className && output.push(className);
+
+  return output;
+};
+
+var getPassthroughProps = function getPassthroughProps(props) {
+  var cssModule = props.cssModule,
+      className = props.className,
+      name = props.name,
+      size = props.size,
+      spin = props.spin,
+      pulse = props.pulse,
+      border = props.border,
+      fixedWidth = props.fixedWidth,
+      inverse = props.inverse,
+      flip = props.flip,
+      rotate = props.rotate,
+      stack = props.stack,
+      output = _objectWithoutProperties(props, ['cssModule', 'className', 'name', 'size', 'spin', 'pulse', 'border', 'fixedWidth', 'inverse', 'flip', 'rotate', 'stack']);
+
+  return output;
+};
+exports.getPassthroughProps = getPassthroughProps;

--- a/src/FALI.js
+++ b/src/FALI.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { getPassthroughProps, formatClassName } from './utils/';
+
+const fali = (props) => {
+  const classNames = formatClassName(props, 'fa-li fa')
+  const passthroughProps = getPassthroughProps(props)
+
+  return (
+    <li {...passthroughProps}><i className={classNames.join(' ')}></i>{ props.children }</li>
+  )
+}
+
+export default fali

--- a/src/FAUL.js
+++ b/src/FAUL.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { getPassthroughProps, formatClassName } from './utils/';
+
+const faul = (props) => {
+  const classNames = formatClassName(props, 'fa-ul')
+  const passthroughProps = getPassthroughProps(props)
+
+  return (
+    <ul className={classNames.join(' ')} {...passthroughProps}>
+      { props.children }
+    </ul>
+  )
+}
+
+export default faul

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import srOnlyStyle from './screen-reader-styles'
+import { formatClassName, getPassthroughProps } from './utils/';
+import FAUL from './FAUL';
+import FALI from './FALI';
 
 /**
  * A React component for the font-awesome icon library.
@@ -29,57 +32,17 @@ class FontAwesome extends React.Component {
   }
 
   render() {
+    const classNames = formatClassName(this.props, 'fa')
     const {
-      border,
-      cssModule,
-      className,
-      fixedWidth,
-      flip,
-      inverse,
-      name,
-      pulse,
-      rotate,
-      size,
-      spin,
-      stack,
       tag = 'span',
       ariaLabel,
-      ...props
-    } = this.props
+      ...leftoverProps
+    } = getPassthroughProps(this.props)
 
-    const classNames = []
 
-    if (cssModule) {
-      classNames.push(cssModule['fa'])
-      classNames.push(cssModule['fa-' + name])
-      size && classNames.push(cssModule['fa-' + size])
-      spin && classNames.push(cssModule['fa-spin'])
-      pulse && classNames.push(cssModule['fa-pulse'])
-      border && classNames.push(cssModule['fa-border'])
-      fixedWidth && classNames.push(cssModule['fa-fw'])
-      inverse && classNames.push(cssModule['fa-inverse'])
-      flip && classNames.push(cssModule['fa-flip-' + flip])
-      rotate && classNames.push(cssModule['fa-rotate-' + rotate])
-      stack && classNames.push(cssModule['fa-stack-' + stack])
-    } else {
-      classNames.push('fa')
-      classNames.push('fa-' + name)
-      size && classNames.push('fa-' + size)
-      spin && classNames.push('fa-spin')
-      pulse && classNames.push('fa-pulse')
-      border && classNames.push('fa-border')
-      fixedWidth && classNames.push('fa-fw')
-      inverse && classNames.push('fa-inverse')
-      flip && classNames.push('fa-flip-' + flip)
-      rotate && classNames.push('fa-rotate-' + rotate)
-      stack && classNames.push('fa-stack-' + stack)
-    }
-
-    // Add any custom class names at the end.
-    className && classNames.push(className)
     return React.createElement(
       tag,
-      { ...props, 'aria-hidden': true, className: classNames.join(' ') },
+      { ...leftoverProps, 'aria-hidden': true, className: classNames.join(' ') },
       ariaLabel
         ? React.createElement('span', { style: srOnlyStyle }, ariaLabel)
         : null
@@ -105,3 +68,5 @@ FontAwesome.propTypes = {
 }
 
 export default FontAwesome
+
+export { FAUL, FALI }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,73 @@
+export const formatClassName = (props, base) => {
+  const { className, cssModule } = props
+  const propsToFormat = [
+    'name',
+    'size',
+    'spin',
+    'pulse',
+    'border',
+    'fixedWidth',
+    'inverse',
+    'flip',
+    'rotate',
+    'stack'
+  ]
+
+  let output = cssModule ? [ cssModule[base] ] : [ base ]
+
+  let simpleFormatter = (appendValue) => {
+    return `fa-${appendValue}`
+  }
+
+  let complexFormatter = (appendValue1, appendValue2) => {
+    return `fa-${appendValue1}-${appendValue2}`
+  }
+
+  let formatterMap = {
+    name: (name) => simpleFormatter(name),
+    size: (size) => simpleFormatter(size),
+    spin: () => simpleFormatter('spin'),
+    pulse: () => simpleFormatter('pulse'),
+    border: () => simpleFormatter('border'),
+    fixedWidth: () => simpleFormatter('fw'),
+    inverse: () => simpleFormatter('inverse'),
+    flip: (flipVal) => complexFormatter('flip', flipVal),
+    rotate: (rotateVal) => complexFormatter('rotate', rotateVal),
+    stack: (stackVal) => complexFormatter('stack', stackVal)
+  }
+
+  propsToFormat
+  .map(x => {
+    return {name: x, val: props[x]}
+  })
+  .reduce((accumulator, currentValue) => {
+    return currentValue.val ? output.push(
+      cssModule ?
+        cssModule[formatterMap[currentValue.name](currentValue.val)] :
+        formatterMap[currentValue.name](currentValue.val)
+    ) : output
+  }, output)
+
+  className && output.push(className)
+
+  return output;
+}
+
+export const getPassthroughProps = (props) => {
+  const {
+    cssModule,
+    className,
+    name,
+    size,
+    spin,
+    pulse,
+    border,
+    fixedWidth,
+    inverse,
+    flip,
+    rotate,
+    stack,
+    ...output
+  } = props
+  return output
+}

--- a/test/list-test.js
+++ b/test/list-test.js
@@ -1,0 +1,54 @@
+/* eslint no-unused-expressions:0 */
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+import jsdom from 'mocha-jsdom'
+import { FALI, FAUL } from '../src'
+
+describe('react-fontawesome lists', () => {
+  let component
+  let classes
+  let ariaHidden
+  let props
+
+  // Use mocha-jsdom.
+  jsdom({ html: '<div id="root"></div>' })
+
+  describe('UL', () => {
+    it('should properly render UL', () => {
+      const expectedClasses = [
+        'my-custom-class',
+        'fa-ul'
+      ]
+      ReactDOM.render(
+        <FAUL id="my-ul" className="my-custom-class" />,
+        document.getElementById('root')
+      )
+      classes = ReactDOM.findDOMNode(document.getElementById('my-ul')).className.split(' ')
+      expectedClasses.forEach(name => expect(classes).to.include(name))
+    })
+  })
+  describe('LI', () => {
+    it('should properly render LIs', () => {
+      const props = {
+        name: 'caret-right',
+        spin: true,
+        pulse: false,
+        id: 'my-li'
+      }
+      const expectedClasses = [
+        'fa',
+        'fa-li',
+        'fa-caret-right',
+        'fa-spin'
+      ]
+      ReactDOM.render(
+        <FALI {...props}>Hello!</FALI>,
+        document.getElementById('root')
+      )
+      debugger
+      classes = ReactDOM.findDOMNode(document.getElementById('my-li')).children[0].className.split(' ')
+      expectedClasses.forEach(name => expect(classes).to.include(name))
+    })
+  })
+})

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,55 @@
+import { formatClassName, getPassthroughProps } from '../src/utils/';
+
+describe('react-fontawesome utils', () => {
+  let classes
+  let props
+  let passthroughProps
+
+  beforeEach(() => {
+    props = {
+      border: true,
+      className: 'my-custom-class',
+      fixedWidth: true,
+      flip: 'vertical',
+      inverse: true,
+      name: 'rocket',
+      size: 'lg',
+      spin: true,
+      pulse: true,
+      rotate: 180,
+      stack: '1x',
+      thisIsNotThePropYouAreLookingFor: true
+    }
+
+    classes = formatClassName(props, 'fa')
+    passthroughProps = getPassthroughProps(props)
+  })
+
+  describe('formatClassName', () => {
+    it('should return the proper class names', () => {
+      let expectedClasses = [
+        'fa',
+        'fa-border',
+        'fa-flip-vertical',
+        'fa-fw',
+        'fa-inverse',
+        'fa-lg',
+        'fa-rocket',
+        'fa-pulse',
+        'fa-rotate-180',
+        'fa-spin',
+        'fa-stack-1x',
+        'my-custom-class',
+      ]
+      expectedClasses.forEach(name => expect(classes).to.include(name))
+    })
+  })
+  describe('getPassthroughProps', () => {
+    it('should return the correct props', () => {
+      let expectedLeftoverProps = [
+        'thisIsNotThePropYouAreLookingFor'
+      ]
+      expectedLeftoverProps.forEach(name => expect(passthroughProps[name]).to.be.equal(true))
+    })
+  })
+})


### PR DESCRIPTION
Could have used className and prepended list item with base FontAwesome component, but that would have been messy. I also cleaned up the class composition, which required another function to prune the props that are going to be passed onto the root elements.

Let me know what you think. If you'd prefer to build the class list for each component while maintaining the cssModule support, then I can remove those bits - I just think it reads better this way and cleans up the components.